### PR TITLE
fix issue on session_regenerate.

### DIFF
--- a/system/Session/Handlers/DatabaseHandler.php
+++ b/system/Session/Handlers/DatabaseHandler.php
@@ -164,7 +164,10 @@ class DatabaseHandler extends BaseHandler implements \SessionHandlerInterface
 		}
 
 		// Needed by write() to detect session_regenerate_id() calls
-		$this->sessionID = $sessionID;
+		if(is_null($this->sessionID))
+		{
+			$this->sessionID = $sessionID;
+		}
 
 		$builder = $this->db->table($this->table)
 				->select('data')
@@ -228,11 +231,6 @@ class DatabaseHandler extends BaseHandler implements \SessionHandlerInterface
 		// Was the ID regenerated?
 		elseif ($sessionID !== $this->sessionID)
 		{
-			if (! $this->releaseLock() || ! $this->lockSession($sessionID))
-			{
-				return $this->fail();
-			}
-
 			$this->rowExists = false;
 			$this->sessionID = $sessionID;
 		}

--- a/system/Session/Handlers/FileHandler.php
+++ b/system/Session/Handlers/FileHandler.php
@@ -187,7 +187,10 @@ class FileHandler extends BaseHandler implements \SessionHandlerInterface
 			}
 
 			// Needed by write() to detect session_regenerate_id() calls
-			$this->sessionID = $sessionID;
+			if(is_null($this->sessionID))
+			{
+				$this->sessionID = $sessionID;
+			}
 
 			if ($this->fileNew)
 			{
@@ -233,10 +236,9 @@ class FileHandler extends BaseHandler implements \SessionHandlerInterface
 	public function write($sessionID, $sessionData): bool
 	{
 		// If the two IDs don't match, we have a session_regenerate_id() call
-		// and we need to close the old handle and open a new one
-		if ($sessionID !== $this->sessionID && (! $this->close() || $this->read($sessionID) === false))
+		if ($sessionID !== $this->sessionID)
 		{
-			return false;
+			$this->sessionID = $sessionID;
 		}
 
 		if (! is_resource($this->fileHandle))
@@ -294,7 +296,7 @@ class FileHandler extends BaseHandler implements \SessionHandlerInterface
 			flock($this->fileHandle, LOCK_UN);
 			fclose($this->fileHandle);
 
-			$this->fileHandle = $this->fileNew = $this->sessionID = null;
+			$this->fileHandle = $this->fileNew = null;
 
 			return true;
 		}

--- a/system/Session/Handlers/MemcachedHandler.php
+++ b/system/Session/Handlers/MemcachedHandler.php
@@ -183,7 +183,10 @@ class MemcachedHandler extends BaseHandler implements \SessionHandlerInterface
 		if (isset($this->memcached) && $this->lockSession($sessionID))
 		{
 			// Needed by write() to detect session_regenerate_id() calls
-			$this->sessionID = $sessionID;
+			if(is_null($this->sessionID))
+			{
+				$this->sessionID = $sessionID;
+			}
 
 			$session_data      = (string) $this->memcached->get($this->keyPrefix . $sessionID);
 			$this->fingerprint = md5($session_data);

--- a/system/Session/Handlers/RedisHandler.php
+++ b/system/Session/Handlers/RedisHandler.php
@@ -184,7 +184,10 @@ class RedisHandler extends BaseHandler implements \SessionHandlerInterface
 		if (isset($this->redis) && $this->lockSession($sessionID))
 		{
 			// Needed by write() to detect session_regenerate_id() calls
-			$this->sessionID = $sessionID;
+			if(is_null($this->sessionID))
+			{
+				$this->sessionID = $sessionID;
+			}
 
 			$session_data                               = $this->redis->get($this->keyPrefix . $sessionID);
 			is_string($session_data) ? $this->keyExists = true : $session_data = '';


### PR DESCRIPTION
There is a problem when doing session_regenerate(), because when we call read() it always affect $this->sessionID = $sessionID which means that in write() function you can't detect a $sessionID regenerate, because when we get there the $this->sessionID is always equal to $sessionID.

This happen because when session_regenerate() is call, this function executes internally and in the following order:

-    write() (with the initial session;
-    close();
-    open();
-    read() (already with the new session) .

Checklist:

- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide